### PR TITLE
Add simple harness to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-1. Build binaries
-   * `cd src ; make`
+## Quickstart
 
-2. Load data
-   * create tables
-     `tarantool create_table.sql`
-   * populate data
-     - simple step
-       `tpcc_load -w 1000`
-                 |WAREHOUSES|
-       ref. tpcc_load --help for all options
+1. Install build dependencies: msgpack, tarantool-c.
+2. Build tpcc: `cd src; make`.
+3. Run tarantool instance: `tarantool create_table.lua`.
+4. Load data: `tpcc_load -w1000` (see other options below).
+5. Start workload: `./tpcc_start -w1000 -r10 -l10800`.
 
-3. Start benchmark
-   * `./tpcc_start -w1000 -r10 -l10800`
-   * |WAREHOUSES| |WARMUP TIME| |BENCHMARK TIME|
-   * ref. tpcc_start --help for all options 
+## Options
 
-Output
-===================================
+* `-w` warehouses;
+* `-r` warmup time;
+* `-l` benchmark time;
+* `-i` report interval.
+
+See `./tpcc_load --help` and `./tpcc_start --help` for more information.
+
+## Output
 
 With the defined interval (-i option), the tool will produce the following output:
+
 ```
   10, trx: 12920, 95%: 9.483, 99%: 18.738, max_rt: 213.169, 12919|98.778, 1292|101.096, 1293|443.955, 1293|670.842
   20, trx: 12666, 95%: 7.074, 99%: 15.578, max_rt: 53.733, 12668|50.420, 1267|35.846, 1266|58.292, 1267|37.421
@@ -28,9 +28,44 @@ With the defined interval (-i option), the tool will produce the following outpu
 ```
 
 Where: 
-* 10 - the seconds from the start of the benchmark
-* trx: 12920 - New Order transactions executed during the gived interval (in this case, for the previous 10 sec). Basically this is the throughput per interval. The more the better
-* 95%: 9.483: - The 95% Response time of New Order transactions per given interval. In this case it is 9.483 sec
-* 99%: 18.738: - The 99% Response time of New Order transactions per given interval. In this case it is 18.738 sec
-* max_rt: 213.169: - The Max Response time of New Order transactions per given interval. In this case it is 213.169 sec
-* the rest: `12919|98.778, 1292|101.096, 1293|443.955, 1293|670.842` is throughput and max response time for the other kind of transactions and can be ignored
+
+* 10 - the seconds from the start of the benchmark.
+* trx: 12920 - New Order transactions executed during the gived interval (in
+  this case, for the previous 10 sec). Basically this is the throughput per
+  interval. More is better.
+* 95%: 9.483: - The 95% Response time of New Order transactions per given
+  interval. In this case it is 9.483 sec.
+* 99%: 18.738: - The 99% Response time of New Order transactions per given
+  interval. In this case it is 18.738 sec.
+* max_rt: 213.169: - The Max Response time of New Order transactions per given
+  interval. In this case it is 213.169 sec.
+* the rest: `12919|98.778, 1292|101.096, 1293|443.955, 1293|670.842` is
+  throughput and max response time for the other kind of transactions and can
+  be ignored.
+
+## Simple harness
+
+```sh
+TPCC_SRC_DIR="$(realpath .)"
+TARANTOOL_SRC_DIR=<...>
+TPCC_RESULTS_DIR=<...>
+cp create_table.lua "${TARANTOOL_SRC_DIR}"
+
+for w in 1 2 3 4 5 10 15; do
+    cd "${TARANTOOL_SRC_DIR}"
+    rm 00000*
+    ./src/tarantool create_table.lua &
+    sleep 5
+    cd "${TPCC_SRC_DIR}"
+    ./tpcc_load -w${w}
+
+    for c in 10; do
+        for i in $(seq 1 3); do
+            ./tpcc_start -w${w} -r10 -l30 -i30 -c${c} >> "${TPCC_RESULTS_DIR}/tarantool-res-w${w}-c${c}.txt"
+        done
+    done
+
+    killall tarantool
+    wait
+done
+```

--- a/create_table.lua
+++ b/create_table.lua
@@ -1,6 +1,5 @@
-box.cfg{
-    wal_mode = 'none',
-}
+box.cfg{listen = 3301, memtx_memory = 10 * 1024^3}
+box.schema.user.grant('guest', 'read,write,execute', 'universe')
 
 box.sql.execute("drop table if exists warehouse;")
 box.sql.execute("create table warehouse ( \
@@ -144,7 +143,3 @@ box.sql.execute("CREATE INDEX idx_customer ON customer (c_w_id,c_d_id,c_last,c_f
 box.sql.execute("CREATE INDEX idx_orders ON orders (o_w_id,o_d_id,o_c_id,o_id);")
 box.sql.execute("CREATE INDEX fkey_stock_2 ON stock (s_i_id);")
 box.sql.execute("CREATE INDEX fkey_order_line_2 ON order_line (ol_supply_w_id,ol_i_id);")
-
-box.snapshot()
-
-os.exit()


### PR DESCRIPTION
Changed create_table.lua to allow to use it as a file for a tarantool
instance.

Clarified README a bit.