### PR TITLE
fix: fix box.sql.execute, schema, infinite retries

### DIFF
--- a/create_table.lua
+++ b/create_table.lua
@@ -1,8 +1,10 @@
 box.cfg{listen = 3301, memtx_memory = 10 * 1024^3}
 box.schema.user.grant('guest', 'read,write,execute', 'universe')
 
-box.sql.execute("drop table if exists warehouse;")
-box.sql.execute("create table warehouse ( \
+local sql_execute = box.sql and box.sql.execute or box.execute
+
+sql_execute("drop table if exists warehouse;")
+sql_execute("create table warehouse ( \
 w_id int not null, \
 w_name varchar(10), \
 w_street_1 varchar(20), \
@@ -10,12 +12,12 @@ w_street_2 varchar(20), \
 w_city varchar(20), \
 w_state varchar(2), \
 w_zip varchar(9), \
-w_tax varchar(7), \
-w_ytd varchar(15), \
+w_tax number, \
+w_ytd number, \
 primary key (w_id) )")
 
-box.sql.execute("drop table if exists district;")
-box.sql.execute("create table district ( \
+sql_execute("drop table if exists district;")
+sql_execute("create table district ( \
 d_id int not null, \
 d_w_id int not null, \
 d_name varchar(10), \
@@ -24,14 +26,14 @@ d_street_2 varchar(20), \
 d_city varchar(20), \
 d_state varchar(2), \
 d_zip varchar(9), \
-d_tax varchar(7), \
-d_ytd varchar(15), \
+d_tax number, \
+d_ytd number, \
 d_next_o_id int, \
 primary key (d_w_id, d_id), \
 FOREIGN KEY(d_w_id) REFERENCES warehouse(w_id) );")
 
-box.sql.execute("drop table if exists customer;")
-box.sql.execute("create table customer ( \
+sql_execute("drop table if exists customer;")
+sql_execute("create table customer ( \
 c_id int not null, \
 c_d_id int not null, \
 c_w_id int not null, \
@@ -47,17 +49,17 @@ c_phone varchar(16), \
 c_since varchar(100), \
 c_credit varchar(2), \
 c_credit_lim int, \
-c_discount varchar(7), \
-c_balance varchar(15), \
-c_ytd_payment varchar(15), \
+c_discount number, \
+c_balance number, \
+c_ytd_payment number, \
 c_payment_cnt int, \
 c_delivery_cnt int, \
 c_data text, \
 PRIMARY KEY(c_w_id, c_d_id, c_id), \
 FOREIGN KEY(c_w_id,c_d_id) REFERENCES district(d_w_id,d_id) );")
 
-box.sql.execute("drop table if exists history;")
-box.sql.execute("create table history ( \
+sql_execute("drop table if exists history;")
+sql_execute("create table history ( \
 _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \
 h_c_id int, \
 h_c_d_id int, \
@@ -65,13 +67,13 @@ h_c_w_id int, \
 h_d_id int, \
 h_w_id int, \
 h_date varchar(100), \
-h_amount varchar(9), \
+h_amount number, \
 h_data varchar(24), \
 FOREIGN KEY(h_c_w_id,h_c_d_id,h_c_id) REFERENCES customer(c_w_id,c_d_id,c_id), \
 FOREIGN KEY(h_w_id,h_d_id) REFERENCES district(d_w_id,d_id) );")
 
-box.sql.execute("drop table if exists orders;")
-box.sql.execute("create table orders ( \
+sql_execute("drop table if exists orders;")
+sql_execute("create table orders ( \
 o_id int not null, \
 o_d_id int not null, \
 o_w_id int not null, \
@@ -83,25 +85,25 @@ o_all_local int, \
 PRIMARY KEY(o_w_id, o_d_id, o_id), \
 FOREIGN KEY(o_w_id,o_d_id,o_c_id) REFERENCES customer(c_w_id,c_d_id,c_id) );")
 
-box.sql.execute("drop table if exists new_orders;")
-box.sql.execute("create table new_orders ( \
+sql_execute("drop table if exists new_orders;")
+sql_execute("create table new_orders ( \
 no_o_id int not null, \
 no_d_id int not null, \
 no_w_id int not null, \
 PRIMARY KEY(no_w_id, no_d_id, no_o_id), \
 FOREIGN KEY(no_w_id,no_d_id,no_o_id) REFERENCES orders(o_w_id,o_d_id,o_id));")
 
-box.sql.execute("drop table if exists item;")
-box.sql.execute("create table item ( \
+sql_execute("drop table if exists item;")
+sql_execute("create table item ( \
 i_id int not null, \
 i_im_id int, \
 i_name varchar(24), \
-i_price varchar(8), \
+i_price number, \
 i_data varchar(50), \
 PRIMARY KEY(i_id) );")
 
-box.sql.execute("drop table if exists stock;")
-box.sql.execute("create table stock ( \
+sql_execute("drop table if exists stock;")
+sql_execute("create table stock ( \
 s_i_id int not null, \
 s_w_id int not null, \
 s_quantity int, \
@@ -123,8 +125,8 @@ PRIMARY KEY(s_w_id, s_i_id), \
 FOREIGN KEY(s_w_id) REFERENCES warehouse(w_id), \
 FOREIGN KEY(s_i_id) REFERENCES item(i_id) );")
 
-box.sql.execute("drop table if exists order_line;")
-box.sql.execute("create table order_line ( \
+sql_execute("drop table if exists order_line;")
+sql_execute("create table order_line ( \
 ol_o_id int not null, \
 ol_d_id int not null, \
 ol_w_id int not null, \
@@ -133,13 +135,13 @@ ol_i_id int, \
 ol_supply_w_id int, \
 ol_delivery_d varchar(100), \
 ol_quantity int, \
-ol_amount varchar(9), \
+ol_amount number, \
 ol_dist_info varchar(24), \
 PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number), \
 FOREIGN KEY(ol_w_id,ol_d_id,ol_o_id) REFERENCES orders(o_w_id,o_d_id,o_id), \
 FOREIGN KEY(ol_supply_w_id,ol_i_id) REFERENCES stock(s_w_id,s_i_id) );")
 
-box.sql.execute("CREATE INDEX idx_customer ON customer (c_w_id,c_d_id,c_last,c_first);")
-box.sql.execute("CREATE INDEX idx_orders ON orders (o_w_id,o_d_id,o_c_id,o_id);")
-box.sql.execute("CREATE INDEX fkey_stock_2 ON stock (s_i_id);")
-box.sql.execute("CREATE INDEX fkey_order_line_2 ON order_line (ol_supply_w_id,ol_i_id);")
+sql_execute("CREATE INDEX idx_customer ON customer (c_w_id,c_d_id,c_last,c_first);")
+sql_execute("CREATE INDEX idx_orders ON orders (o_w_id,o_d_id,o_c_id,o_id);")
+sql_execute("CREATE INDEX fkey_stock_2 ON stock (s_i_id);")
+sql_execute("CREATE INDEX fkey_order_line_2 ON order_line (ol_supply_w_id,ol_i_id);")


### PR DESCRIPTION
In older tarantool versions querying with sql was supposed to be done
with box.sql.execute, however it was changed to box.execute in newer
ones. This lead to not being able to create a valid snapshot on newer
version of Tarantool. SQL compatibility also changed over the years
so the types were also changed. Retries were handled very dirty, so
I also added a threshold for tpcc_load not to enter an infinite loop
that is very unpleasant to debug