### PR TITLE
Turn the benchmark back to life

### DIFF
--- a/create_table.lua
+++ b/create_table.lua
@@ -1,8 +1,13 @@
 box.cfg{listen = 3301, memtx_memory = 10 * 1024^3}
 box.schema.user.grant('guest', 'read,write,execute', 'universe')
 
-box.sql.execute("drop table if exists warehouse;")
-box.sql.execute("create table warehouse ( \
+-- Prior to 2.2.1 box.sql.execute was used for SQL queries.
+if not box.execute then
+    box.execute = box.sql.execute
+end
+
+box.execute("drop table if exists warehouse;")
+box.execute("create table warehouse ( \
 w_id int not null, \
 w_name varchar(10), \
 w_street_1 varchar(20), \
@@ -14,8 +19,8 @@ w_tax varchar(7), \
 w_ytd varchar(15), \
 primary key (w_id) )")
 
-box.sql.execute("drop table if exists district;")
-box.sql.execute("create table district ( \
+box.execute("drop table if exists district;")
+box.execute("create table district ( \
 d_id int not null, \
 d_w_id int not null, \
 d_name varchar(10), \
@@ -30,8 +35,8 @@ d_next_o_id int, \
 primary key (d_w_id, d_id), \
 FOREIGN KEY(d_w_id) REFERENCES warehouse(w_id) );")
 
-box.sql.execute("drop table if exists customer;")
-box.sql.execute("create table customer ( \
+box.execute("drop table if exists customer;")
+box.execute("create table customer ( \
 c_id int not null, \
 c_d_id int not null, \
 c_w_id int not null, \
@@ -56,8 +61,8 @@ c_data text, \
 PRIMARY KEY(c_w_id, c_d_id, c_id), \
 FOREIGN KEY(c_w_id,c_d_id) REFERENCES district(d_w_id,d_id) );")
 
-box.sql.execute("drop table if exists history;")
-box.sql.execute("create table history ( \
+box.execute("drop table if exists history;")
+box.execute("create table history ( \
 _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \
 h_c_id int, \
 h_c_d_id int, \
@@ -70,8 +75,8 @@ h_data varchar(24), \
 FOREIGN KEY(h_c_w_id,h_c_d_id,h_c_id) REFERENCES customer(c_w_id,c_d_id,c_id), \
 FOREIGN KEY(h_w_id,h_d_id) REFERENCES district(d_w_id,d_id) );")
 
-box.sql.execute("drop table if exists orders;")
-box.sql.execute("create table orders ( \
+box.execute("drop table if exists orders;")
+box.execute("create table orders ( \
 o_id int not null, \
 o_d_id int not null, \
 o_w_id int not null, \
@@ -83,16 +88,16 @@ o_all_local int, \
 PRIMARY KEY(o_w_id, o_d_id, o_id), \
 FOREIGN KEY(o_w_id,o_d_id,o_c_id) REFERENCES customer(c_w_id,c_d_id,c_id) );")
 
-box.sql.execute("drop table if exists new_orders;")
-box.sql.execute("create table new_orders ( \
+box.execute("drop table if exists new_orders;")
+box.execute("create table new_orders ( \
 no_o_id int not null, \
 no_d_id int not null, \
 no_w_id int not null, \
 PRIMARY KEY(no_w_id, no_d_id, no_o_id), \
 FOREIGN KEY(no_w_id,no_d_id,no_o_id) REFERENCES orders(o_w_id,o_d_id,o_id));")
 
-box.sql.execute("drop table if exists item;")
-box.sql.execute("create table item ( \
+box.execute("drop table if exists item;")
+box.execute("create table item ( \
 i_id int not null, \
 i_im_id int, \
 i_name varchar(24), \
@@ -100,8 +105,8 @@ i_price varchar(8), \
 i_data varchar(50), \
 PRIMARY KEY(i_id) );")
 
-box.sql.execute("drop table if exists stock;")
-box.sql.execute("create table stock ( \
+box.execute("drop table if exists stock;")
+box.execute("create table stock ( \
 s_i_id int not null, \
 s_w_id int not null, \
 s_quantity int, \
@@ -123,8 +128,8 @@ PRIMARY KEY(s_w_id, s_i_id), \
 FOREIGN KEY(s_w_id) REFERENCES warehouse(w_id), \
 FOREIGN KEY(s_i_id) REFERENCES item(i_id) );")
 
-box.sql.execute("drop table if exists order_line;")
-box.sql.execute("create table order_line ( \
+box.execute("drop table if exists order_line;")
+box.execute("create table order_line ( \
 ol_o_id int not null, \
 ol_d_id int not null, \
 ol_w_id int not null, \
@@ -139,7 +144,7 @@ PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number), \
 FOREIGN KEY(ol_w_id,ol_d_id,ol_o_id) REFERENCES orders(o_w_id,o_d_id,o_id), \
 FOREIGN KEY(ol_supply_w_id,ol_i_id) REFERENCES stock(s_w_id,s_i_id) );")
 
-box.sql.execute("CREATE INDEX idx_customer ON customer (c_w_id,c_d_id,c_last,c_first);")
-box.sql.execute("CREATE INDEX idx_orders ON orders (o_w_id,o_d_id,o_c_id,o_id);")
-box.sql.execute("CREATE INDEX fkey_stock_2 ON stock (s_i_id);")
-box.sql.execute("CREATE INDEX fkey_order_line_2 ON order_line (ol_supply_w_id,ol_i_id);")
+box.execute("CREATE INDEX idx_customer ON customer (c_w_id,c_d_id,c_last,c_first);")
+box.execute("CREATE INDEX idx_orders ON orders (o_w_id,o_d_id,o_c_id,o_id);")
+box.execute("CREATE INDEX fkey_stock_2 ON stock (s_i_id);")
+box.execute("CREATE INDEX fkey_order_line_2 ON order_line (ol_supply_w_id,ol_i_id);")

--- a/create_table.lua
+++ b/create_table.lua
@@ -15,8 +15,8 @@ w_street_2 varchar(20), \
 w_city varchar(20), \
 w_state varchar(2), \
 w_zip varchar(9), \
-w_tax varchar(7), \
-w_ytd varchar(15), \
+w_tax double, \
+w_ytd double, \
 primary key (w_id) )")
 
 box.execute("drop table if exists district;")
@@ -29,8 +29,8 @@ d_street_2 varchar(20), \
 d_city varchar(20), \
 d_state varchar(2), \
 d_zip varchar(9), \
-d_tax varchar(7), \
-d_ytd varchar(15), \
+d_tax double, \
+d_ytd double, \
 d_next_o_id int, \
 primary key (d_w_id, d_id), \
 FOREIGN KEY(d_w_id) REFERENCES warehouse(w_id) );")
@@ -52,9 +52,9 @@ c_phone varchar(16), \
 c_since varchar(100), \
 c_credit varchar(2), \
 c_credit_lim int, \
-c_discount varchar(7), \
-c_balance varchar(15), \
-c_ytd_payment varchar(15), \
+c_discount double, \
+c_balance double, \
+c_ytd_payment double, \
 c_payment_cnt int, \
 c_delivery_cnt int, \
 c_data text, \
@@ -70,7 +70,7 @@ h_c_w_id int, \
 h_d_id int, \
 h_w_id int, \
 h_date varchar(100), \
-h_amount varchar(9), \
+h_amount double, \
 h_data varchar(24), \
 FOREIGN KEY(h_c_w_id,h_c_d_id,h_c_id) REFERENCES customer(c_w_id,c_d_id,c_id), \
 FOREIGN KEY(h_w_id,h_d_id) REFERENCES district(d_w_id,d_id) );")
@@ -101,7 +101,7 @@ box.execute("create table item ( \
 i_id int not null, \
 i_im_id int, \
 i_name varchar(24), \
-i_price varchar(8), \
+i_price double, \
 i_data varchar(50), \
 PRIMARY KEY(i_id) );")
 
@@ -120,7 +120,7 @@ s_dist_07 varchar(24), \
 s_dist_08 varchar(24), \
 s_dist_09 varchar(24), \
 s_dist_10 varchar(24), \
-s_ytd varchar(9), \
+s_ytd double, \
 s_order_cnt int, \
 s_remote_cnt int, \
 s_data varchar(50), \
@@ -138,7 +138,7 @@ ol_i_id int, \
 ol_supply_w_id int, \
 ol_delivery_d varchar(100), \
 ol_quantity int, \
-ol_amount varchar(9), \
+ol_amount double, \
 ol_dist_info varchar(24), \
 PRIMARY KEY(ol_w_id, ol_d_id, ol_o_id, ol_number), \
 FOREIGN KEY(ol_w_id,ol_d_id,ol_o_id) REFERENCES orders(o_w_id,o_d_id,o_id), \

--- a/src/mytnt.c
+++ b/src/mytnt.c
@@ -145,8 +145,12 @@ int mytnt_stmt_execute(MYTNT_STMT *stmt) {
 	}
 
 	if (reply->error) {
-		stmt->mytnt->error_info = (char *) malloc(1024 * sizeof(char));
-		strcpy(stmt->mytnt->error_info, reply->error);
+		// Note that reply->error is not a null-terminated string,
+		// so reply->error_end pointer is used to properly copy it
+		// to destination.
+		size_t error_len = reply->error_end - reply->error;
+		stmt->mytnt->error_info = calloc(error_len + 1, sizeof(char));
+		strncpy(stmt->mytnt->error_info, reply->error, error_len);
 		tnt_reply_free(reply);
 		return stmt->mytnt->error_no;
 	}


### PR DESCRIPTION
This request is a couple of changes to let the benchmark work:

1. Adapted to a modern tarantool (box.execute instead of box.sql.execute)
2. A quick workaround to avoid type mismatches for the fields that were of type decimal originally. Values for the mentioned fields are passed as doubles, but for some reason implicit conversions double->string and double->decimal don't work, so for now just change the type of all that fields to double.

Closes #8